### PR TITLE
Create multiple passport strategies

### DIFF
--- a/routes/api/owner.js
+++ b/routes/api/owner.js
@@ -8,11 +8,11 @@ module.exports = function (app) {
     // Using the passport.authenticate middleware with our local strategy.
     // If the owner has valid login credentials, send them to the members page.
     // Otherwise the owner will be sent an error
-    app.post("/api/owner_login", passport.authenticate("local"), (req, res) => {
+    app.post("/api/owner_login", passport.authenticate("local-owner"), (req, res) => {
         // Sending back a password, even a hashed password, isn't a good idea
         res.json({
-            email: req.owner.email,
-            id: req.owner.id
+            email: req.user.email,
+            id: req.user.id
         });
     });
 
@@ -42,7 +42,7 @@ module.exports = function (app) {
     app.get("/api/owner_data", (req, res) => {
         if (!req.owner) {
             // The owner is not logged in, send back an empty object
-            res.json({});
+            res.json({ it: 'does not work' });
         } else {
             // Otherwise send back the owner's email and id
             // Sending back a password, even a hashed password, isn't a good idea
@@ -58,39 +58,39 @@ module.exports = function (app) {
         }
     });
 
-    app.put("/api/add_owner_profile", function(req, res) {
+    app.put("/api/add_owner_profile", function (req, res) {
         db.Owner.update(
-          req.body,
-          {
-            where: {
-              id: req.body.id
-            }
-          }).then(function(dbOwner) {
-          res.json(dbOwner);
-        });
+            req.body,
+            {
+                where: {
+                    id: req.body.id
+                }
+            }).then(function (dbOwner) {
+                res.json(dbOwner);
+            });
     });
 
-    app.put("/api/add_owner_schedule", function(req, res) {
+    app.put("/api/add_owner_schedule", function (req, res) {
         db.Owner.update(
-          req.body,
-          {
-            where: {
-              id: req.body.id
-            }
-          }).then(function(dbOwner) {
-          res.json(dbOwner);
-        });
+            req.body,
+            {
+                where: {
+                    id: req.body.id
+                }
+            }).then(function (dbOwner) {
+                res.json(dbOwner);
+            });
     });
 
-    app.get("/api/match", function(req, res) {
+    app.get("/api/match", function (req, res) {
         db.Owner.findAll({
-          where: {
-            zipCode: 78950
-          },
-          include: [db.Walker]
-        }).then(function(dbOwner) {
+            where: {
+                zipCode: 78950
+            },
+            include: [db.Walker]
+        }).then(function (dbOwner) {
             console.log(dbOwner);
-          res.json(dbOwner);
+            res.json(dbOwner);
         });
     });
 };

--- a/routes/api/walker.js
+++ b/routes/api/walker.js
@@ -4,80 +4,80 @@
 const db = require("../../models");
 const passport = require("../../config/passport");
 
-module.exports = function(app) {
-  // Using the passport.authenticate middleware with our local strategy.
-  // If the user has valid login credentials, send them to the members page.
-  // Otherwise the owner will be sent an error
-  app.post("/api/walker_login", passport.authenticate("local"), (req, res) => {
-    // Sending back a password, even a hashed password, isn't a good idea
-    res.json({
-      email: req.Owner.email,
-      id: req.Owner.id
+module.exports = function (app) {
+    // Using the passport.authenticate middleware with our local strategy.
+    // If the user has valid login credentials, send them to the members page.
+    // Otherwise the owner will be sent an error
+    app.post("/api/walker_login", passport.authenticate("local-walker"), (req, res) => {
+        // Sending back a password, even a hashed password, isn't a good idea
+        res.json({
+            email: req.user.email,
+            id: req.user.id
+        });
     });
-  });
 
-  // Route for signing up the Walker. The walker's password is automatically hashed and stored securely thanks to
-  // how we configured our Sequelize User Model. If the walker is created successfully, proceed to log the user in,
-  // otherwise send back an error
-  app.post("/api/walker_signup", (req, res) => {
-    db.Walker.create({
-      email: req.body.email,
-      password: req.body.password
-    })
-      .then(() => {
-        res.redirect(307, "/api/login");
-      })
-      .catch(err => {
-        res.status(401).json(err);
-      });
-  });
+    // Route for signing up the Walker. The walker's password is automatically hashed and stored securely thanks to
+    // how we configured our Sequelize User Model. If the walker is created successfully, proceed to log the user in,
+    // otherwise send back an error
+    app.post("/api/walker_signup", (req, res) => {
+        db.Walker.create({
+            email: req.body.email,
+            password: req.body.password
+        })
+            .then(() => {
+                res.redirect(307, "/api/login");
+            })
+            .catch(err => {
+                res.status(401).json(err);
+            });
+    });
 
-  // Route for logging walker out
-  app.get("/logout", (req, res) => {
-    req.logout();
-    res.redirect("/");
-  });
+    // Route for logging walker out
+    app.get("/logout", (req, res) => {
+        req.logout();
+        res.redirect("/");
+    });
 
-  // Route for getting some data about our Walker to be used client side
-  app.get("/api/walker_data", (req, res) => {
-    if (!req.walker) {
-      // The Walker is not logged in, send back an empty object
-      res.json({});
-    } else {
-      // Otherwise send back the Walker's email and id
-      // Sending back a password, even a hashed password, isn't a good idea
-      res.json({
-        firstName: req.walker.firstName,
-        lastName: req.walker.lastName,
-        email: req.walker.email,
-        zipcode: req.walker.zipcode,
-        dogSize: req.walker.dogSize,
-        id: req.walker.id
-      });
-    }
-  });
-
-  app.put("/api/add_walker_profile", function(req, res) {
-    db.Walker.update(
-      req.body,
-      {
-        where: {
-          id: req.body.id
+    // Route for getting some data about our Walker to be used client side
+    app.get("/api/walker_data", (req, res) => {
+        if (!req.walker) {
+            // The Walker is not logged in, send back an empty object
+            res.json({});
+        } else {
+            // Otherwise send back the Walker's email and id
+            // Sending back a password, even a hashed password, isn't a good idea
+            res.json({
+                firstName: req.walker.firstName,
+                lastName: req.walker.lastName,
+                email: req.walker.email,
+                zipcode: req.walker.zipcode,
+                dogSize: req.walker.dogSize,
+                id: req.walker.id
+            });
         }
-      }).then(function(dbWalker) {
-      res.json(dbWalker);
     });
-  });
 
-  app.put("/api/add_walker_schedule", function(req, res) {
-    db.Walker.update(
-      req.body,
-      {
-        where: {
-          id: req.body.id
-        }
-      }).then(function(dbWalker) {
-      res.json(dbWalker);
+    app.put("/api/add_walker_profile", function (req, res) {
+        db.Walker.update(
+            req.body,
+            {
+                where: {
+                    id: req.body.id
+                }
+            }).then(function (dbWalker) {
+                res.json(dbWalker);
+            });
     });
-  });
+
+    app.put("/api/add_walker_schedule", function (req, res) {
+        db.Walker.update(
+            req.body,
+            {
+                where: {
+                    id: req.body.id
+                }
+            }).then(function (dbWalker) {
+                res.json(dbWalker);
+            });
+    });
 };

--- a/server.js
+++ b/server.js
@@ -13,43 +13,44 @@ app.use(express.urlencoded({ extended: true }));
 app.use(express.json());
 // We need to use sessions to keep track of our user's login status
 app.use(
-  session({ secret: "keyboard cat", resave: true, saveUninitialized: true })
+    session({ secret: "keyboard cat", resave: true, saveUninitialized: true })
 );
 app.use(passport.initialize());
 app.use(passport.session());
 // Serve up static assets (usually on heroku)
 if (process.env.NODE_ENV === "production") {
-  app.use(express.static("client/build"));
+    app.use(express.static("client/build"));
 }
 
 // Add routes, both API and view
+require("./routes/api/owner")(app);
+require("./routes/api/walker")(app);
 app.use(routes);
-require("./routes/api/owner");
-require("./routes/api/walker");
+
 
 // Start the API server
 db.sequelize.sync().then(() => {
- 
-  db.Owner.create({
-    dogName: "Rufus", 
-    lastName: "Ruff", 
-    dogBreed: "Dalmation", 
-    dogSize: 50,
-    email: "suzi@example.com",
-    password: "suziQ789",
-    zipcode: 78950
-  });
 
-  db.Walker.create({
-    firstName: "Kyle", 
-    lastName: "Walkson", 
-    email: "kyle@example.com",
-    password: "kyle666",
-    zipcode: 78950,
-    dogSize: 33
-  });
+    db.Owner.create({
+        dogName: "Rufus",
+        lastName: "Ruff",
+        dogBreed: "Dalmation",
+        dogSize: 50,
+        email: "suzi@example.com",
+        password: "suziQ789",
+        zipcode: 78950
+    });
 
-  app.listen(PORT, function() {
-    console.log(`🌎  ==> API Server now listening on PORT ${PORT}!`);
-  });
+    db.Walker.create({
+        firstName: "Kyle",
+        lastName: "Walkson",
+        email: "kyle@example.com",
+        password: "kyle666",
+        zipcode: 78950,
+        dogSize: 33
+    });
+
+    app.listen(PORT, function () {
+        console.log(`🌎  ==> API Server now listening on PORT ${PORT}!`);
+    });
 });


### PR DESCRIPTION
I've set this up so you can use a different passport strategy for owners vs walkers. When you do a post request to api/walker_login it should use the local-walker strategy. A post request to api/owner_login will use the local-owner strategy.